### PR TITLE
feat: 프로필 컴포넌트 UI 구현

### DIFF
--- a/src/components/ProfileContainer.jsx
+++ b/src/components/ProfileContainer.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import styled from 'styled-components';
+import { Link } from 'react-router-dom';
+import BasicProfile from '../components/profileImg/BasicProfile';
+import Button from './common/button/Button';
+
+const ProfileWrap = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+const ProfileFollowWrap = styled.div`
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-around;
+`;
+
+const ButtonWrap = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 10px;
+  margin: 0 auto; ;
+`;
+
+const FollowersLink = styled(Link)`
+  display: flex;
+  flex-direction: column;
+  font-weight: 700;
+  font-size: 18px;
+  text-align: center;
+
+  & span:last-child {
+    font-weight: 400;
+    font-size: 10px;
+    color: var(--subtitle-text);
+  }
+`;
+
+const ProfileDescriptionWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+const UserName = styled.strong`
+  font-weight: 700;
+  font-size: 16px;
+  margin: 16px 0 6px;
+`;
+
+const UserId = styled.span`
+  font-weight: 400;
+  font-size: 12px;
+  color: var(--subtitle-text);
+`;
+
+const UserIntro = styled(UserId)`
+  font-size: 14px;
+  margin: 16px 0 24px;
+`;
+
+const FollowingLink = styled(FollowersLink)`
+  color: var(--subtitle-text);
+`;
+
+export default function ProfileContainer() {
+  const userInfo = JSON.parse(localStorage.getItem('userInfo'));
+  const { username, accountname, intro, image, token } = userInfo.user;
+
+  return (
+    <ProfileWrap>
+      <h3 className='ir'>프로필</h3>
+      <ProfileFollowWrap>
+        <FollowersLink to='#none'>
+          <span>2950</span>
+          <span>followers</span>
+        </FollowersLink>
+        <BasicProfile />
+        <FollowingLink to='#none'>
+          <span>128</span>
+          <span>followings</span>
+        </FollowingLink>
+      </ProfileFollowWrap>
+
+      <ProfileDescriptionWrap>
+        <UserName>{accountname}</UserName>
+        <UserId>{username}</UserId>
+        <UserIntro>{intro}</UserIntro>
+      </ProfileDescriptionWrap>
+      <ButtonWrap>
+        <Button medium white>
+          프로필 수정
+        </Button>
+        <Button medium100 white>
+          상품 등록
+        </Button>
+      </ButtonWrap>
+    </ProfileWrap>
+  );
+}

--- a/src/components/userProfile/ProfileContainer.jsx
+++ b/src/components/userProfile/ProfileContainer.jsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import styled from 'styled-components';
+import { useState } from 'react';
+import { useEffect } from 'react';
+import ProfileDataCard from './ProfileDataCard';
+
+const ProfileWrap = styled.section`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default function ProfileContainer(props) {
+  const [userData, setUserData] = useState();
+
+  async function GetUserProfileData(accountname, token) {
+    const url = 'https://mandarin.api.weniv.co.kr';
+    const reqPath = `/profile/${accountname}`;
+    try {
+      const res = await fetch(url + reqPath, {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+      const resData = await res.json();
+      return resData;
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  useEffect(() => {
+    const userInfo = JSON.parse(localStorage.getItem('userInfo'));
+    if (!userInfo) {
+      console.log('로그인 정보가 없습니다.');
+      props.history.push('/login');
+      return;
+    }
+
+    const { accountname, token } = userInfo.user;
+    const UserProfileData = GetUserProfileData(accountname, token);
+    UserProfileData.then((userData) => {
+      console.log('userData', userData);
+      setUserData(userData);
+    });
+  }, []);
+
+  return (
+    <>
+      {userData && (
+        <ProfileWrap>
+          <ProfileDataCard userData={userData} />
+        </ProfileWrap>
+      )}
+    </>
+  );
+}

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -1,14 +1,9 @@
 import React from 'react';
-import styled from 'styled-components';
+import BasicProfile from '../profileImg/BasicProfile';
+import Button from '../common/button/Button';
 import { Link } from 'react-router-dom';
-import BasicProfile from '../components/profileImg/BasicProfile';
-import Button from './common/button/Button';
+import styled from 'styled-components';
 
-const ProfileWrap = styled.section`
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-`;
 const ProfileFollowWrap = styled.div`
   width: 100%;
   display: flex;
@@ -20,7 +15,8 @@ const ButtonWrap = styled.div`
   display: flex;
   justify-content: center;
   gap: 10px;
-  margin: 0 auto; ;
+  margin: 0 auto;
+  text-align: center;
 `;
 
 const FollowersLink = styled(Link)`
@@ -64,21 +60,19 @@ const FollowingLink = styled(FollowersLink)`
   color: var(--subtitle-text);
 `;
 
-export default function ProfileContainer() {
-  const userInfo = JSON.parse(localStorage.getItem('userInfo'));
-  const { username, accountname, intro, image, token } = userInfo.user;
-
+export default function ProfileDataCard(props) {
+  const { followerCount, followingCount, username, intro, accountname } =
+    props?.userData.profile;
   return (
-    <ProfileWrap>
-      <h3 className='ir'>프로필</h3>
+    <>
       <ProfileFollowWrap>
-        <FollowersLink to='#none'>
-          <span>2950</span>
+        <FollowersLink to='/follower'>
+          <span>{followerCount}</span>
           <span>followers</span>
         </FollowersLink>
         <BasicProfile />
-        <FollowingLink to='#none'>
-          <span>128</span>
+        <FollowingLink to='/following'>
+          <span>{followingCount}</span>
           <span>followings</span>
         </FollowingLink>
       </ProfileFollowWrap>
@@ -89,13 +83,13 @@ export default function ProfileContainer() {
         <UserIntro>{intro}</UserIntro>
       </ProfileDescriptionWrap>
       <ButtonWrap>
-        <Button medium white>
+        <Button as={Link} to='/프로필수정페이지' medium white>
           프로필 수정
         </Button>
-        <Button medium100 white>
+        <Button as={Link} to='/상품등록페이지' medium100 white>
           상품 등록
         </Button>
       </ButtonWrap>
-    </ProfileWrap>
+    </>
   );
 }


### PR DESCRIPTION
1. my 프로필 페이지 진입시 나타나는 프로필 페이지 상단 컴포넌트 UI 구현했습니다.
2. 팔로워, 팔로잉 클릭시 연결되는 부분은 미 구현 상태입니다.
3. 프로필 수정, 상품 등록 버튼 클릭시 기능은 미 구현 상태입니다.

----

현재 기능구현이 조금 늦어지는 것 같아 우선은 UI부터 올립니다.
프로필수정, 상품등록 버튼이 페이지 이동이라고 생각되어 링크태그로 감쌌는데 다른분들 의견이 궁금합니다.

----
### 다음 진행사항
1. 상대 프로필 클릭시 보여지는 컴포넌트와 동일한 구조이므로 재사용성을 위한 컴포넌트 수정
2. 팔로워, 팔로잉 api서버로부터 받아와 데이터 연결
