### PR TITLE
fix: props에 as속성 사용시 boolean 값 명시해주지 않으면 생기는 오류 메세지 해결

### DIFF
--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -88,10 +88,10 @@ export default function ProfileDataCard(props) {
         <UserIntro>{intro}</UserIntro>
       </ProfileDescriptionWrap>
       <ButtonWrap>
-        <Button as={Link} to='/프로필수정페이지' medium white>
+        <Button as={Link} to='/프로필수정페이지' medium='true' white='true'>
           프로필 수정
         </Button>
-        <Button as={Link} to='/상품등록페이지' medium100 white>
+        <Button as={Link} to='/상품등록페이지' medium100='true' white='true'>
           상품 등록
         </Button>
       </ButtonWrap>


### PR DESCRIPTION
1. button props에 as속성을 사용하면 불리언값을 지정해주라는 에러메세지가 나오기 떄문에 true값을 넣어주어 해결했습니다.
<img width="547" alt="스크린샷 2022-07-14 오후 3 55 41" src="https://user-images.githubusercontent.com/97894417/178920467-fc34d3bc-8222-4c26-b90e-4081fb95c59a.png">