### PR TITLE
feat: 프로필카드에 팔로잉, 팔로우 버튼 UI컴포넌트 추가 

### DIFF
--- a/src/components/userProfile/ProfileContainer.jsx
+++ b/src/components/userProfile/ProfileContainer.jsx
@@ -11,12 +11,12 @@ const ProfileWrap = styled.section`
   padding: 30px 0 26px;
 `;
 
-export default function ProfileContainer(props) {
+export default function ProfileContainer({ userId, ...props }) {
   const [userData, setUserData] = useState();
 
-  async function GetUserProfileData(accountname, token) {
+  async function GetUserProfileData(userId, token) {
     const url = 'https://mandarin.api.weniv.co.kr';
-    const reqPath = `/profile/${accountname}`;
+    const reqPath = `/profile/${userId}`;
     try {
       const res = await fetch(url + reqPath, {
         method: 'GET',
@@ -40,8 +40,8 @@ export default function ProfileContainer(props) {
       return;
     }
 
-    const { accountname, token } = userInfo.user;
-    const UserProfileData = GetUserProfileData(accountname, token);
+    const { token } = userInfo.user;
+    const UserProfileData = GetUserProfileData(userId, token);
     UserProfileData.then((userData) => {
       setUserData(userData);
     });

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -3,6 +3,8 @@ import UserProfileImg from '../profileImg/UserProfileImg';
 import Button from '../common/button/Button';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import messageCircle from '../../assets/icon/icon-comment.svg';
+import share from '../../assets/icon/icon-share.svg';
 
 const ProfileFollowWrap = styled.div`
   width: 100%;
@@ -64,9 +66,27 @@ const FollowingLink = styled(FollowersLink)`
   color: var(--subtitle-text);
 `;
 
+const MessageLink = styled(Link)`
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid var(--border-gray);
+  background-image: url(${messageCircle});
+  background-position: center;
+  background-size: 20px 20px;
+  background-repeat: no-repeat;
+`;
+
+const ShareLink = styled(MessageLink)`
+  background-image: url(${share});
+`;
+
 export default function ProfileDataCard(props) {
   const { followerCount, followingCount, username, intro, accountname } =
     props?.userData.profile;
+  const myAccount = JSON.parse(localStorage.getItem('userInfo')).user
+    .accountname;
+
   return (
     <>
       <ProfileFollowWrap>
@@ -87,12 +107,30 @@ export default function ProfileDataCard(props) {
         <UserIntro>{intro}</UserIntro>
       </ProfileDescriptionWrap>
       <ButtonWrap>
-        <Button as={Link} to='/프로필수정페이지' medium='true' white='true'>
-          프로필 수정
-        </Button>
-        <Button as={Link} to='/상품등록페이지' medium100='true' white='true'>
-          상품 등록
-        </Button>
+        {myAccount !== accountname ? (
+          <>
+            <MessageLink to='#none'></MessageLink>
+            <Button medium='true'>팔로우</Button>
+            <Button medium='true' white='true'>
+              언팔로우
+            </Button>
+            <ShareLink to='#none'></ShareLink>
+          </>
+        ) : (
+          <>
+            <Button as={Link} to='/프로필수정페이지' medium='true' white='true'>
+              프로필 수정
+            </Button>
+            <Button
+              as={Link}
+              to='/상품등록페이지'
+              medium100='true'
+              white='true'
+            >
+              상품 등록
+            </Button>
+          </>
+        )}
       </ButtonWrap>
     </>
   );

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -82,6 +82,7 @@ const ShareLink = styled(MessageLink)`
 `;
 
 export default function ProfileDataCard(props) {
+  console.log(props);
   const { followerCount, followingCount, username, intro, accountname } =
     props?.userData.profile;
   const myAccount = JSON.parse(localStorage.getItem('userInfo')).user
@@ -102,8 +103,8 @@ export default function ProfileDataCard(props) {
       </ProfileFollowWrap>
 
       <ProfileDescriptionWrap>
-        <UserName>{accountname}</UserName>
-        <UserId>{username}</UserId>
+        <UserName>{username}</UserName>
+        <UserId>@ {accountname}</UserId>
         <UserIntro>{intro}</UserIntro>
       </ProfileDescriptionWrap>
       <ButtonWrap>

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -95,7 +95,7 @@ export default function ProfileDataCard(props) {
           <FollowText>followers</FollowText>
         </FollowersLink>
         <UserProfileImg />
-        <FollowingLink to='/ollowing'>
+        <FollowingLink to='/following'>
           <Count>{followingCount}</Count>
           <FollowText>followings</FollowText>
         </FollowingLink>

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -83,7 +83,7 @@ const ShareLink = styled(MessageLink)`
 
 export default function ProfileDataCard(props) {
   console.log(props);
-  const { followerCount, followingCount, username, intro, accountname } =
+  const { followerCount, followingCount, username, intro, accountname, image } =
     props?.userData.profile;
   const myAccount = JSON.parse(localStorage.getItem('userInfo')).user
     .accountname;
@@ -95,7 +95,7 @@ export default function ProfileDataCard(props) {
           <Count>{followerCount}</Count>
           <FollowText>followers</FollowText>
         </FollowersLink>
-        <UserProfileImg />
+        <UserProfileImg src={image} />
         <FollowingLink to='/following'>
           <Count>{followingCount}</Count>
           <FollowText>followings</FollowText>


### PR DESCRIPTION
1. 프로필카드에 팔로잉, 팔로우 버튼 컴포넌트를 추가했습니다. 
2. 현재 기능구현은 되지않은 상태입니다.

#110 

1. 기존 로컬데이터만 받아와 로그인 유저 데이터만을 보여주던 로직을 상위컴포넌트에서 props로 userId를 받아와 userId로 인식하여 데이터를 뿌려줄 수 있도록 수정하였습니다.

#119 