### PR TITLE
refactor: ProfileImage 컴포넌트 확장성을 위해 리팩토링

### DIFF
--- a/src/components/profileImg/UserProfileImg.jsx
+++ b/src/components/profileImg/UserProfileImg.jsx
@@ -1,40 +1,39 @@
 import React from 'react';
 import basicProfile from '../../assets/basic-profile.png';
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
+
+const handleSizeType = (size) => {
+  switch (size) {
+    case 'tiny':
+      return css`
+        width: 36px;
+        height: 36px;
+      `;
+    case 'small':
+      return css`
+        width: 42px;
+        height: 42px;
+      `;
+    case 'medium':
+      return css`
+        width: 50px;
+        height: 50px;
+      `;
+    default:
+      return css`
+        width: 110px;
+        height: 110px;
+      `;
+  }
+};
 
 const ProfileImage = styled.img`
-  width: 110px;
-  height: 110px;
   border-radius: 50%;
-`;
 
-const MediumProfileImage = styled.img`
-  width: 50px;
-  height: 50px;
-  border-radius: 50%;
-`;
-
-const SmallProfileImage = styled.img`
-  width: 42px;
-  height: 42px;
-  border-radius: 50%;
-`;
-
-const TinyProfileImage = styled.img`
-  width: 36px;
-  height: 36px;
-  border-radius: 50%;
+  ${(props) => handleSizeType(props.size)}
 `;
 
 export default function UserProfile(props) {
   //프로필 이미지 사이즈 별로 사용시 UserProfile의 props.size에 해당 값을 전달하여 사용
-  if (props.size === 'tiny') {
-    return <TinyProfileImage src={props.src || basicProfile} />;
-  } else if (props.size === 'small') {
-    return <SmallProfileImage src={props.src || basicProfile} />;
-  } else if (props.size === 'medium') {
-    return <MediumProfileImage src={props.src || basicProfile} />;
-  } else {
-    return <ProfileImage src={props.src || basicProfile} />;
-  }
+  return <ProfileImage {...props} src={props.src || basicProfile} />;
 }


### PR DESCRIPTION
기존 ProfileImage 컴포넌트에 중복코드가 상당히 많고, props를 받으려면 중복된코드에 모두 추가해줘야한다는 단점을 보완했습니다.