### PR TITLE
feat: PostViewChangeNav컴포넌트에 게시글(리스트형/앨범형)  전환 기능 추가

### DIFF
--- a/src/components/common/nav/PostViewChangeNav.jsx
+++ b/src/components/common/nav/PostViewChangeNav.jsx
@@ -6,34 +6,54 @@ import postListOff from '../../../assets/icon/icon-post-list-off.svg';
 import postListOn from '../../../assets/icon/icon-post-list-on.svg';
 
 const Button = css`
-  width: 40px;
-  height: 40px;
+  width: 26px;
+  height: 26px;
   background-repeat: no-repeat;
   background-position: center;
+  margin-right: 16px;
 `;
 
 const PostListView = styled.button`
   ${Button}
   background-image: url(${postListOn});
+  ${(props) =>
+    !props.isPostListView &&
+    css`
+      background-image: url(${postListOff});
+    `}
 `;
 
 const PostAlbumView = styled.button`
   ${Button}
   background-image: url(${postAlbumOff});
+  ${(props) =>
+    props.isPostAlbumView &&
+    css`
+      background-image: url(${postAlbumOn});
+    `}
 `;
 
 const ToggleButtonWrap = styled.div`
   text-align: right;
   border-bottom: 0.5px solid var(--border-gray);
+  padding: 9px 0;
 `;
 
-export default function PostViewChangeNav() {
+export default function PostViewChangeNav(props) {
   return (
-    <>
-      <ToggleButtonWrap>
-        <PostListView />
-        <PostAlbumView />
-      </ToggleButtonWrap>
-    </>
+    <ToggleButtonWrap>
+      <PostListView
+        type='button'
+        onClick={props.onClick}
+        disabled={props.disabled}
+        isPostListView={props.isPostListView}
+      />
+      <PostAlbumView
+        type='button'
+        onClick={props.onClick}
+        disabled={!props.disabled}
+        isPostAlbumView={props.isPostAlbumView}
+      />
+    </ToggleButtonWrap>
   );
 }

--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -37,7 +37,7 @@ const UserId = styled.span`
 `;
 
 const MoreButton = styled.button`
-  padding: 10px;
+  padding: 7px;
   background-image: url(${more});
   background-position: center;
   background-repeat: no-repeat;

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -1,6 +1,6 @@
-import React from 'react';
-import { useState, useEffect } from 'react';
-import styled from 'styled-components';
+import React, { useState, useEffect } from 'react';
+import styled, { css } from 'styled-components';
+import PostViewChangeNav from '../common/nav/PostViewChangeNav';
 import PostItem from './PostItem';
 
 const PostItemUl = styled.ul`
@@ -8,6 +8,13 @@ const PostItemUl = styled.ul`
   & > li + li {
     margin-top: 16px;
   }
+  ${(props) =>
+    props.isPostView &&
+    css`
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 8px;
+    `}
 `;
 
 export default function PostList({ userId, ...props }) {
@@ -35,12 +42,36 @@ export default function PostList({ userId, ...props }) {
     }
     userPostGet();
   }, []);
+  const [isPostView, setIsPostView] = useState(true);
+  function ChangePostView() {
+    setIsPostView((current) => !current);
+  }
 
   return (
-    <PostItemUl className={props.className}>
-      {posts.map((post) => (
-        <PostItem key={post.id} post={post} />
-      ))}
-    </PostItemUl>
+    <>
+      <PostViewChangeNav
+        onClick={ChangePostView}
+        disabled={isPostView}
+        isPostListView={isPostView}
+        isPostAlbumView={!isPostView}
+      />
+      <PostItemUl className={props.className} isPostView={!isPostView}>
+        {isPostView ? (
+          <>
+            {posts.map((post) => (
+              <PostItem key={post.id} post={post} />
+            ))}
+          </>
+        ) : (
+          <>
+            {posts.map((post) => (
+              <li key={post.id}>
+                <img src={post.image} alt='게시글상품사진' />
+              </li>
+            ))}
+          </>
+        )}
+      </PostItemUl>
+    </>
   );
 }


### PR DESCRIPTION
 1. PostList컴포넌트에 PostViewChangeNav컴포넌트를 추가했습니다. 
 2. isPostView 상태를 저장해 PostListView와 PostAlbumView를 구분하였습니다.
 3. PostListView에 onClick, disabled, isPostListView, isPostAlbumView props를 추가했습니다. 
 4. onClick함수는 PostList에서 ChangePostView함수를 받아옵니다. 이 함수가 실행될 떄 isPostView의 상태값을 변경시킵니다. 
 5. disabled는 isPostView상태에 따라 버튼이 활성화, 비활성화 됩니다. 
 6. isPostListView, isPostAlbumView는 상태값에 따른 버튼의 이미지를 변화시키는데 보다 명시적으로 알려주기위해 추가하였습니다.
 7. MoreButton의 padding값을 수정하였습니다.

---
### 기능구현 영상
![chrome-capture-2022-6-20](https://user-images.githubusercontent.com/97894417/180006515-70d78114-5340-45da-9e82-df462edc99a6.gif)

@qorlgns1 @SeoHee3478 @CosmicLatte009 