### PR TITLE
feat: 포스트뷰/앨범뷰 버튼 클릭 시 이미지 예외처리 함수추가 

### DIFF
--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 import UserProfile from '../../components/profileImg/UserProfileImg';
 import heart from '../../assets/icon/icon-heart.svg';
@@ -144,7 +145,9 @@ export default function PostItem({ post }) {
         {postListViewCheck(post.image)}
         <ButtonWrap>
           <HeartButton>{post.heartCount}</HeartButton>
-          <CommentButton>{post.commentCount}</CommentButton>
+          <CommentButton as={Link} to={`/post/${post.id}`}>
+            {post.commentCount}
+          </CommentButton>
         </ButtonWrap>
         <CreatedDate>{`${year}년 ${month}월 ${day}일`}</CreatedDate>
       </PostContentWrap>

--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -133,11 +133,15 @@ export default function PostItem({ post }) {
   return (
     <PostWrap>
       <PostAuthorWrap>
-        <UserProfile size='tiny' src={post.author.image} />
-        <UserWrap>
-          <UserName>{post.author.username}</UserName>
-          <UserId>@ {post.author.accountname}</UserId>
-        </UserWrap>
+        <Link to={`/profile/${post.author.accountname}`}>
+          <UserProfile size='tiny' src={post.author.image} />
+        </Link>
+        <Link to={`/profile/${post.author.accountname}`}>
+          <UserWrap>
+            <UserName>{post.author.username}</UserName>
+            <UserId>@ {post.author.accountname}</UserId>
+          </UserWrap>
+        </Link>
         <MoreButton />
       </PostAuthorWrap>
       <PostContentWrap>

--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -58,7 +58,17 @@ const Text = styled.p`
   word-break: break-all;
 `;
 
-const PostImg = styled.img``;
+const PostImg = styled.img`
+  width: 304px;
+  height: 228px;
+  border-radius: 10px;
+  object-fit: contain;
+`;
+
+const PostImages = styled.div`
+  display: flex;
+  overflow-x: auto;
+`;
 
 const ButtonWrap = styled.div`
   margin: 12px 0 16px;
@@ -101,6 +111,24 @@ export default function PostItem({ post }) {
   }
   const [year, month, day] = parseDate(post.createdAt);
 
+  function postListViewCheck(image) {
+    const URL = 'https://mandarin.api.weniv.co.kr';
+
+    if (!image) {
+      return false;
+    } else if (!image.includes(URL)) {
+      return <PostImg src='' alt='이미지 파일을 불러올 수 없습니다.' />;
+    } else {
+      return (
+        <PostImages>
+          {image.split(',').map((postImg, index) => (
+            <PostImg key={index} src={postImg} alt='게시글상품사진' />
+          ))}
+        </PostImages>
+      );
+    }
+  }
+
   return (
     <PostWrap>
       <PostAuthorWrap>
@@ -113,9 +141,7 @@ export default function PostItem({ post }) {
       </PostAuthorWrap>
       <PostContentWrap>
         <Text>{post.content}</Text>
-        {post.image === '' ? null : (
-          <PostImg src={post.image} alt='게시글상품사진' />
-        )}
+        {postListViewCheck(post.image)}
         <ButtonWrap>
           <HeartButton>{post.heartCount}</HeartButton>
           <CommentButton>{post.commentCount}</CommentButton>

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -65,19 +65,22 @@ export default function PostList({ userId, ...props }) {
     const URL = 'https://mandarin.api.weniv.co.kr';
 
     return posts.map((post, index) => {
-      console.log(post.id);
       if (!post.image.includes(URL) || !post.image) {
         return false;
       } else if (post.image.includes(',')) {
         return (
           <MultiImgLi key={index}>
-            <img src={post.image.split(',')[0]} alt='게시글상품사진' />
+            <Link to={`/post/${post.id}`}>
+              <img src={post.image.split(',')[0]} alt='게시글상품사진' />
+            </Link>
           </MultiImgLi>
         );
       } else {
         return (
           <li key={index}>
-            <img src={post.image} alt='게시글상품사진' />
+            <Link to={`/post/${post.id}`}>
+              <img src={post.image} alt='게시글상품사진' />
+            </Link>
           </li>
         );
       }

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -1,7 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import styled, { css } from 'styled-components';
+import { Link } from 'react-router-dom';
 import PostViewChangeNav from '../common/nav/PostViewChangeNav';
 import PostItem from './PostItem';
+import multiImage from '../../assets/icon/iccon-img-layers.svg';
 
 const PostItemUl = styled.ul`
   margin: 16px 16px 30px;
@@ -15,6 +17,18 @@ const PostItemUl = styled.ul`
       grid-template-columns: repeat(3, 1fr);
       gap: 8px;
     `}
+`;
+
+const MultiImgLi = styled.li`
+  position: relative;
+  &::before {
+    content: url(${multiImage});
+    width: 20px;
+    height: 20px;
+    position: absolute;
+    top: 6px;
+    right: 6px;
+  }
 `;
 
 export default function PostList({ userId, ...props }) {
@@ -43,14 +57,37 @@ export default function PostList({ userId, ...props }) {
     userPostGet();
   }, []);
   const [isPostView, setIsPostView] = useState(true);
-  function ChangePostView() {
+  function changePostView() {
     setIsPostView((current) => !current);
+  }
+
+  function postAlbumViewCheck(posts) {
+    const URL = 'https://mandarin.api.weniv.co.kr';
+
+    return posts.map((post, index) => {
+      console.log(post.id);
+      if (!post.image.includes(URL) || !post.image) {
+        return false;
+      } else if (post.image.includes(',')) {
+        return (
+          <MultiImgLi key={index}>
+            <img src={post.image.split(',')[0]} alt='게시글상품사진' />
+          </MultiImgLi>
+        );
+      } else {
+        return (
+          <li key={index}>
+            <img src={post.image} alt='게시글상품사진' />
+          </li>
+        );
+      }
+    });
   }
 
   return (
     <>
       <PostViewChangeNav
-        onClick={ChangePostView}
+        onClick={changePostView}
         disabled={isPostView}
         isPostListView={isPostView}
         isPostAlbumView={!isPostView}
@@ -63,13 +100,7 @@ export default function PostList({ userId, ...props }) {
             ))}
           </>
         ) : (
-          <>
-            {posts.map((post) => (
-              <li key={post.id}>
-                <img src={post.image} alt='게시글상품사진' />
-              </li>
-            ))}
-          </>
+          <>{postAlbumViewCheck(posts)}</>
         )}
       </PostItemUl>
     </>

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -65,7 +65,7 @@ export default function PostList({ userId, ...props }) {
     const URL = 'https://mandarin.api.weniv.co.kr';
 
     return posts.map((post, index) => {
-      if (!post.image.includes(URL) || !post.image) {
+      if (!post.image || !post.image.includes(URL)) {
         return false;
       } else if (post.image.includes(',')) {
         return (


### PR DESCRIPTION
#### 앨범뷰
1. 이미지 URL이 빈 문자열/ 잘못된 문자열 이라면 보여주지 않는다.
2. 이미지 URL이 2개 이상이라면 다중 아이콘을 붙여준다.
3. 위 모든게 아니라면 그냥 이미지만 보여준다.

---

#### 리스트뷰
1. 이미지 URL이 빈 문자열 이라면 보여주지않는다.
2. 이미지 URL이 2개 이상이라면 모든 이미지를 가로스크롤을 이용해 보여준다.
3. 이미지 URL이 이상한 문자열 이라면 에러이미지를 보여준다. alt="이미지를 불러오지 못했습니다." 

---

- 이미지 게시글 댓글 클릭 시 상세 페이지로 이동
- 이미지 포스트 클릭 시 상세 페이지로 이동

---

**질문Q1. 이미지파일을 불러올 수 없을 때기본 이미지를 넣는건 어떻게 생각하시나요?**
아래는 현재 잘못된 URL을 사용해 이미지를 업로드 한 경우 나오는 모습입니다.
![스크린샷 2022-07-21 오후 8 11 07](https://user-images.githubusercontent.com/97894417/180200216-eba856e6-870c-4123-a1ee-751d9b25fa04.png)

