### PR TITLE
fix: splash화면이 오른쪽으로 치우쳐지는 오류 해결

### DIFF
--- a/src/components/splash/Splash.jsx
+++ b/src/components/splash/Splash.jsx
@@ -17,7 +17,6 @@ const SplashImg = styled.img`
 `;
 
 const FlexCenter = styled.div`
-  width: 100%;
   height: 100%;
   display: flex;
   justify-content: conter;
@@ -26,6 +25,7 @@ const FlexCenter = styled.div`
 
 const AniSplash = styled.div`
   position: absolute;
+  left: 0;
   width: 100%;
   height: 100%;
   background-color: var(--bg-color);

--- a/src/pages/LoginHomePage.jsx
+++ b/src/pages/LoginHomePage.jsx
@@ -6,7 +6,7 @@ import LoginCard from '../components/login/LoginCard';
 import Splash from '../components/splash/Splash';
 
 const LoginContainer = styled.main`
-  width: 100%;
+  margin: 0 -1500px;
   height: 100vh;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
1. splash화면이 index.jsx에서 작성된 AppFixedWrap 속성 값 때문에 오른쪽으로 치우쳐지는 것을 수정했습니다.
2. LoginHomePage 역시 위와 같은이유로 화면이 잘리는 현상을 수정했습니다.