### PR TITLE
fix: 삭제 모달과 게시글 컴포넌트 겹치는 문제 fix

### DIFF
--- a/src/components/common/modal/DeleteModal.jsx
+++ b/src/components/common/modal/DeleteModal.jsx
@@ -5,6 +5,7 @@ const ModalBackground = styled.div`
   position: fixed;
   inset: 0;
   background: rgba(0, 0, 0, 0.8);
+  z-index: 1;
 `;
 
 const ModalWrap = styled.div`


### PR DESCRIPTION
1. DeleteModal.jsx에서 z-index 추가하여 겹치는 문제 해결

#169