### PR TITLE
feat: 게시글 목록을 불러오는 limit 추가

### DIFF
--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -6,7 +6,7 @@ import PostItem from './PostItem';
 import multiImage from '../../assets/icon/iccon-img-layers.svg';
 
 const PostItemUl = styled.ul`
-  margin: 16px 16px 30px;
+  margin: 16px 16px 80px;
   & > li + li {
     margin-top: 16px;
   }
@@ -37,8 +37,7 @@ export default function PostList({ userId, ...props }) {
   async function userPostGet() {
     const userInfo = JSON.parse(localStorage.getItem('userInfo')).user;
     const url = 'https://mandarin.api.weniv.co.kr';
-    const reqPath = `/post/${userId}/userpost`;
-
+    const reqPath = `/post/${userId}/userpost/?limit=${parseInt(20)}`;
     try {
       const res = await fetch(url + reqPath, {
         method: 'GET',
@@ -97,7 +96,7 @@ export default function PostList({ userId, ...props }) {
         isPostListView={isPostView}
         isPostAlbumView={!isPostView}
       />
-      <PostItemUl className={props.className} isPostView={!isPostView}>
+      <PostItemUl isPostView={!isPostView}>
         {isPostView ? (
           <>
             {posts.map((post) => (

--- a/src/components/post/PostList.jsx
+++ b/src/components/post/PostList.jsx
@@ -6,8 +6,8 @@ import PostItem from './PostItem';
 import multiImage from '../../assets/icon/iccon-img-layers.svg';
 
 const PostItemUl = styled.ul`
-  margin: 16px 16px 80px;
-  & > li + li {
+  margin: 0 16px 80px;
+  & > li {
     margin-top: 16px;
   }
   ${(props) =>


### PR DESCRIPTION
    1. 게시글 목록을 불러오는 limit를 추가했습니다. (현재 최신게시글 20개까지만 보여집니다|추후 무한스크롤 구현 예정)
    2. PostItmeUl 에 불필요한 className을 제거했습니다.
    3. 게시글 마지막하단이 하단 네브바에 가려지는 문제를 해결했습니다.
    4. 게시글 모달버튼 클릭 시 게시글 리스트 상단의 마진이 사라지는 문제 해결