### PR TITLE
refactor: 게시물상세페이지에서 새롭게 게시물데이터를 조회하고 보여줄 수 있도록 수정

### DIFF
--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -250,17 +250,7 @@ export default function PostItem({ post, userPostGet }) {
               />
               {postHeartCount}
             </IconWrap>
-            <IconWrap
-              onClick={() =>
-                history.push(`/post/${id}`, {
-                  post: {
-                    ...post,
-                    hearted: isHearted,
-                    heartCount: postHeartCount,
-                  },
-                })
-              }
-            >
+            <IconWrap onClick={() => history.push(`/post/${id}`)}>
               <CommentSvg />
               {commentCount}
             </IconWrap>

--- a/src/pages/PostPage.jsx
+++ b/src/pages/PostPage.jsx
@@ -1,10 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import TopNavBasic from '../components/common/nav/TopNavBasic';
 import PostItem from '../components/post/PostItem';
 import CommentAddBox from '../components/post/CommentAddBox';
 import CommentItem from '../components/post/CommentItem';
-import { axiosGetPostComments } from '../apis/postApi';
+import { axiosGetPostComments, axiosGetPostDetail } from '../apis/postApi';
 
 const PostItemWrap = styled.main`
   margin: 20px 16px 24px;
@@ -21,20 +21,32 @@ const CommentListWrap = styled.section`
   }
 `;
 export default function PostPage({ location, match, ...props }) {
+  const [postId] = useState(match.params.post_id);
+
+  const [post, setPost] = useState();
   const [comments, setComments] = useState([]);
 
   useEffect(() => {
-    const { post_id } = match.params;
-    axiosGetPostComments(post_id).then(({ comments }) => {
+    axiosGetPostDetail(postId).then(({ post }) => {
+      setPost(post);
+    });
+
+    axiosGetPostComments(postId).then(({ comments }) => {
       setComments(comments);
     });
   }, []);
+
+  useEffect(() => {
+    axiosGetPostDetail(postId).then(({ post }) => {
+      setPost(post);
+    });
+  }, [comments]);
 
   return (
     <>
       <TopNavBasic viewMore {...props} />
       <PostItemWrap>
-        <PostItem post={location.state.post} />
+        {post && <PostItem post={post} />}
         <CommentListWrap>
           {comments.map((comment) => (
             <CommentItem


### PR DESCRIPTION
프로필페이지에서 게시물을 불러오고 그 데이터를 게시물 상세페이지에 전달했었는데 데이터를 불러오고 다른 많은사람들이 하트버튼을 눌렀을수도 있으니 새롭게 게시물을 조회할 수 있도록 수정