### PR TITLE
Refactor: AccessToken/RefreshToken 적용 및 인증 리팩토링

### DIFF
--- a/src/apis/endpoints.js
+++ b/src/apis/endpoints.js
@@ -1,0 +1,11 @@
+// API endpoints
+export const ENDPOINTS = {
+  USER: {
+    REFRESH: '/user/refresh',
+    LOGIN: '/user/login',
+    JOIN: '/user',
+    LOGOUT: '/user/logout',
+  },
+};
+
+export default ENDPOINTS;

--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -1,5 +1,11 @@
 import axios from 'axios';
-import { getUserInfo } from '../utils/userInfo';
+import {
+  getAccessToken,
+  setAccessToken,
+  clearAll,
+  setCurrentUser,
+} from './tokenStorage';
+import { axiosRefreshToken } from './profileApi';
 
 export const API_URL = 'https://soon-my-room.kihoonbae.store/api';
 
@@ -15,13 +21,33 @@ export const axiosInstanceWithToken = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true, // 쿠키를 요청에 포함
 });
 
-axiosInstanceWithToken.interceptors.request.use((request) => {
-  // axiosInstanceWithToken에서 토큰이 존재하지 않으면 서버에 request를 보내지 않습니다.
-  const { token } = getUserInfo();
+axiosInstanceWithToken.interceptors.request.use(async (request) => {
+  // 메모리에서 토큰을 가져옵니다
+  const token = getAccessToken();
   if (!token) {
-    throw new Error('토큰이 없습니다. 다시 로그인해주세요.');
+    try {
+      // Refresh Token으로 새 Access Token 요청 (쿠키는 자동으로 포함됨)
+      const response = await axiosRefreshToken();
+
+      const { user } = response.data;
+
+      // 새 Access Token 저장
+      if (user && user.token) {
+        // 메모리에 새 토큰 저장
+        setAccessToken(user.token);
+        request.headers.Authorization = `Bearer ${user.token}`;
+        setCurrentUser(user);
+
+        return request;
+      }
+    } catch (error) {
+      // Refresh Token 요청 실패 시 로그인 페이지로 리다이렉트
+      clearAll();
+      window.location.href = '/login';
+    }
   }
 
   // 토큰이 존재하면 headers에 토큰을 넣어서 서버에 request를 보냅니다.

--- a/src/apis/profileApi.js
+++ b/src/apis/profileApi.js
@@ -1,3 +1,4 @@
+import ENDPOINTS from './endpoints';
 import { axiosInstance, axiosInstanceWithToken } from './index';
 
 export const axiosUserIdValidCheck = async (userId) => {
@@ -20,7 +21,7 @@ export const axiosUserIdValidCheck = async (userId) => {
 export const axiosJoin = async (userInfo) => {
   try {
     const { data } = await axiosInstance.post(
-      `/user`,
+      ENDPOINTS.USER.JOIN,
       JSON.stringify({
         user: userInfo,
       }),
@@ -38,4 +39,18 @@ export const axiosProfileInfoEdit = async (userInfo) => {
   } catch (error) {
     console.error('axiosProfileInfoEdit error', error);
   }
+};
+
+export const axiosRefreshToken = async () => {
+  return axiosInstance.post(
+    ENDPOINTS.USER.REFRESH,
+    {},
+    {
+      withCredentials: true,
+    },
+  );
+};
+
+export const axiosLogout = async () => {
+  return axiosInstanceWithToken.post(ENDPOINTS.USER.LOGOUT, {});
 };

--- a/src/apis/tokenStorage.js
+++ b/src/apis/tokenStorage.js
@@ -1,0 +1,28 @@
+// 메모리 기반 토큰 저장소
+let accessToken = '';
+let currentUser = null;
+
+export const setAccessToken = (token) => {
+  accessToken = token;
+};
+
+export const getAccessToken = () => accessToken;
+
+export const clearAccessToken = () => {
+  accessToken = '';
+};
+
+export const setCurrentUser = (user) => {
+  currentUser = user;
+};
+
+export const getCurrentUser = () => currentUser;
+
+export const clearCurrentUser = () => {
+  currentUser = null;
+};
+
+export const clearAll = () => {
+  clearAccessToken();
+  clearCurrentUser();
+};

--- a/src/components/common/nav/TopNavBasic.jsx
+++ b/src/components/common/nav/TopNavBasic.jsx
@@ -5,6 +5,8 @@ import AlertModal from '../modal/AlertModal';
 import ModalContainer from '../modal/ModalContainer';
 import iconArrowLeft from '../../../assets/icon/icon-arrow-left.svg';
 import iconMore from '../../../assets/icon/icon-more-vertical.svg';
+import { clearAll } from '../../../apis/tokenStorage';
+import { axiosLogout } from '../../../apis/profileApi';
 
 const Navigation = styled.nav`
   padding: 12px 12px 12px 16px;
@@ -57,10 +59,15 @@ export default function TopNavBasic({ title, viewMore, history }) {
     }
   }
 
-  function handleUserTokenDelete() {
-    localStorage.clear();
-    setIsLogoutModal(false);
-    window.location.replace('/');
+  async function handleUserTokenDelete() {
+    try {
+      await axiosLogout();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      clearAll(); // 메모리에서 모든 인증 데이터 제거
+      window.location.replace('/');
+    }
   }
 
   function handleCloseClick() {

--- a/src/components/post/PostItem.jsx
+++ b/src/components/post/PostItem.jsx
@@ -14,6 +14,8 @@ import {
   axiosGetUserPost,
 } from '../../apis/postApi';
 import { API_URL } from '../../apis';
+import { getAccessToken } from '../../apis/tokenStorage';
+import { getUserInfo } from '../../utils/userInfo';
 
 const PostWrap = styled.li`
   display: flex;
@@ -125,9 +127,8 @@ export default function PostItem({ post, setPosts }) {
   const [isLogin, setIsLogin] = useState(false);
   const [isModalAlert, setIsModalAlert] = useState(false);
   const modalRef = useRef();
-  const { token, accountname } = JSON.parse(
-    localStorage.getItem('userInfo'),
-  ).user;
+  const token = getAccessToken();
+  const { accountname } = getUserInfo();
 
   const history = useHistory();
 

--- a/src/components/userProfile/ProfileContainer.jsx
+++ b/src/components/userProfile/ProfileContainer.jsx
@@ -1,8 +1,9 @@
 import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import ProfileDataCard from './ProfileDataCard';
+import { getUserInfo } from '../../utils/userInfo';
+import { getAccessToken } from '../../apis/tokenStorage';
 import { API_URL } from '../../apis';
-import { convertBaseUrlOfServerResponse } from '../../utils/convert';
 
 const ProfileWrap = styled.section`
   display: flex;
@@ -11,7 +12,7 @@ const ProfileWrap = styled.section`
   padding: 30px 0 26px;
 `;
 
-export default function ProfileContainer({ userId, ...props }) {
+export default function ProfileContainer(props) {
   const [userData, setUserData] = useState();
   async function GetUserProfileData(userId, token) {
     const reqPath = `/profile/${userId}`;
@@ -23,26 +24,24 @@ export default function ProfileContainer({ userId, ...props }) {
           'Content-Type': 'application/json',
         },
       });
-      const resData = await res.json();
-      return convertBaseUrlOfServerResponse(resData);
+      return res.json();
     } catch (err) {
       console.error(err);
     }
   }
 
   useEffect(() => {
-    const userInfo = JSON.parse(localStorage.getItem('userInfo'));
+    const userInfo = getUserInfo();
+    const token = getAccessToken();
+
     if (!userInfo) {
       console.log('로그인 정보가 없습니다.');
       props.history.push('/login');
-      return;
     }
 
-    const { token } = userInfo.user;
+    const userId = userInfo.accountname;
     const UserProfileData = GetUserProfileData(userId, token);
-    UserProfileData.then((userData) => {
-      setUserData(userData);
-    });
+    UserProfileData.then(setUserData);
   }, []);
 
   return (

--- a/src/components/userProfile/ProfileDataCard.jsx
+++ b/src/components/userProfile/ProfileDataCard.jsx
@@ -6,6 +6,7 @@ import UserProfileImg from '../profileImg/UserProfileImg';
 import share from '../../assets/icon/icon-share.svg';
 import messageCircle from '../../assets/icon/icon-comment.svg';
 import { axiosRequestFollow, axioxRemoveFollow } from '../../apis/followApi';
+import { getUserInfo } from '../../utils/userInfo';
 
 const ProfileFollowWrap = styled.div`
   width: 100%;
@@ -92,8 +93,7 @@ export default function ProfileDataCard(props) {
     followerCount,
     followingCount,
   } = props?.userData.profile;
-  const myAccount = JSON.parse(localStorage.getItem('userInfo')).user
-    .accountname;
+  const myAccount = getUserInfo().accountname;
   const [isfollowState, setIsfollowState] = useState(isfollow);
   const [userFollowerCount, setUserFollowerCount] = useState(followerCount);
 

--- a/src/pages/LoginHomePage.jsx
+++ b/src/pages/LoginHomePage.jsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 import logoImg from '../assets/full-logo-01.svg';
 import LoginCard from '../components/login/LoginCard';
 import Splash from '../components/splash/Splash';
+import { getUserInfo } from '../utils/userInfo';
 
 const LoginContainer = styled.main`
   height: 100vh;
@@ -23,7 +24,7 @@ export default function LoginHomePage(props) {
   const [isLoginToken, setIsLoginToken] = useState(false);
 
   useEffect(() => {
-    const userInfo = JSON.parse(localStorage.getItem('userInfo'));
+    const userInfo = getUserInfo();
     if (userInfo?.user.token) {
       setTimeout(() => {
         props.history.push('/feed');

--- a/src/pages/LoginPage.jsx
+++ b/src/pages/LoginPage.jsx
@@ -6,6 +6,8 @@ import InputBox from '../components/common/input/InputBox';
 import ErrorMessageBox from '../components/common/input/ErrorMessageBox';
 import EmailSignUp from '../components/email/EmailSignUp';
 import { API_URL } from '../apis';
+import { setAccessToken, setCurrentUser } from '../apis/tokenStorage';
+import ENDPOINTS from '../apis/endpoints';
 
 const LoginForm = styled.form`
   width: 322px;
@@ -59,7 +61,7 @@ export default function LoginPage(props) {
   async function hendleLoginSubmit(e) {
     e.preventDefault();
 
-    const reqPath = '/user/login';
+    const reqPath = ENDPOINTS.USER.LOGIN;
     const userData = {
       user: {
         email: userEmailRef.current.value,
@@ -73,17 +75,17 @@ export default function LoginPage(props) {
           'Content-Type': 'application/json',
         },
         body: JSON.stringify(userData),
+        credentials: 'include', // 쿠키를 받기 위해 필요
       });
       const resData = await res.json();
-      if (resData.message === '이메일 또는 비밀번호가 일치하지 않습니다.') {
+
+      if (resData.detail === '이메일 또는 비밀번호가 일치하지 않습니다.') {
         setErrorMessage('*이메일 또는 비밀번호가 일치하지 않습니다.');
       } else {
-        localStorage.setItem('userInfo', JSON.stringify(resData));
-
-        // userInfo객체의 구조가 userInfo: { user: { ...정보 }} 로 되어있어서 리팩토링하기위해 추가로 userInfo1 설정
-        // 나중에 리팩토링이 끝나면 userInfo1을 userInfo로 바꿀 예정입니다.
-        const { user } = resData;
-        localStorage.setItem('userInfo1', JSON.stringify(user));
+        // Access Token과 사용자 정보를 메모리에 저장
+        const { token, ...userWithoutToken } = resData.user;
+        setAccessToken(token);
+        setCurrentUser(userWithoutToken);
 
         props.history.push('/feed');
       }

--- a/src/pages/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage.jsx
@@ -196,7 +196,6 @@ export default function ProfileEditPage(props) {
       try {
         const userInfo = getUserInfo();
         const updateUserInfo = { ...userInfo, ...profileEditResult.data.user };
-        setUserInfo(updateUserInfo);
         setCurrentUser(updateUserInfo);
       } catch (err) {
         console.error(err);

--- a/src/pages/ProfileEditPage.jsx
+++ b/src/pages/ProfileEditPage.jsx
@@ -11,6 +11,7 @@ import {
   axiosUserIdValidCheck,
 } from '../apis/profileApi';
 import { axiosImageSave } from '../apis/imageApi';
+import { setCurrentUser } from '../apis/tokenStorage';
 
 const ProfileEditWrap = styled.div`
   position: relative;
@@ -192,20 +193,14 @@ export default function ProfileEditPage(props) {
     const profileEditResult = await axiosProfileInfoEdit(editUserInfo);
 
     if (profileEditResult.status === 200) {
-      const userInfo = getUserInfo();
-      const updateUserInfo = {
-        ...userInfo,
-        accountname: profileEditResult.data.user.accountname,
-        image: profileEditResult.data.user.image,
-        intro: profileEditResult.data.user.intro,
-        username: profileEditResult.data.user.username,
-      };
-
-      localStorage.setItem('userInfo1', JSON.stringify(updateUserInfo));
-      localStorage.setItem(
-        'userInfo',
-        JSON.stringify({ user: updateUserInfo }),
-      ); // 나중에 안정화 되면 삭제해야함
+      try {
+        const userInfo = getUserInfo();
+        const updateUserInfo = { ...userInfo, ...profileEditResult.data.user };
+        setUserInfo(updateUserInfo);
+        setCurrentUser(updateUserInfo);
+      } catch (err) {
+        console.error(err);
+      }
 
       props.history.push('/profile');
     } else {

--- a/src/pages/ProfilePage.jsx
+++ b/src/pages/ProfilePage.jsx
@@ -100,7 +100,7 @@ export default function ProfilePage(props) {
     isLoding && (
       <>
         <TopNavBasic viewMore {...props} />
-        <ProfileContainer userId={props.match.params.userId} />
+        <ProfileContainer />
         <ProductListOnSalesWrap
           title='판매 중인 상품'
           products={productListOnSalesData}

--- a/src/utils/route/PrivateRoute.jsx
+++ b/src/utils/route/PrivateRoute.jsx
@@ -1,15 +1,53 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { Redirect, Route } from 'react-router-dom';
 import { getUserInfo } from '../userInfo';
+import { setAccessToken, setCurrentUser } from '../../apis/tokenStorage';
+import { axiosRefreshToken } from '../../apis/profileApi';
 
 export default function PrivateRoute({ children, ...rest }) {
-  const userInfo = getUserInfo();
+  const [isLoading, setIsLoading] = useState(true);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+
+  useEffect(() => {
+    const checkAuth = async () => {
+      const user = getUserInfo();
+
+      if (user) {
+        setIsAuthenticated(true);
+        setIsLoading(false);
+        return;
+      }
+
+      // 사용자 정보가 없으면 토큰 갱신 시도
+      try {
+        const response = await axiosRefreshToken();
+
+        if (response.data && response.data.user) {
+          const { token, ...userWithoutToken } = response.data.user;
+          setAccessToken(token);
+          setCurrentUser(userWithoutToken);
+          setIsAuthenticated(true);
+        }
+      } catch (error) {
+        console.log('인증 실패:', error);
+        setIsAuthenticated(false);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    checkAuth();
+  }, []);
+
+  if (isLoading) {
+    return <div></div>;
+  }
 
   return (
     <Route
       {...rest}
       render={(props) =>
-        userInfo ? (
+        isAuthenticated ? (
           React.cloneElement(children, { ...props })
         ) : (
           <Redirect

--- a/src/utils/userInfo.js
+++ b/src/utils/userInfo.js
@@ -1,10 +1,8 @@
-function getLocalStorageUserInfo() {
-  return JSON.parse(localStorage.getItem('userInfo1'));
-}
+import { getCurrentUser } from '../apis/tokenStorage';
 
 export function getUserInfo() {
   try {
-    const user = getLocalStorageUserInfo();
+    const user = getCurrentUser();
     if (!user) {
       throw new Error('유저정보가 없습니다.');
     }


### PR DESCRIPTION
### 변경 내용
1. **토큰 관리 개선 (AccessToken & RefreshToken 적용)**
   - `localStorage` 기반에서 메모리 기반(`tokenStorage.js`)으로 변경
   - `getAccessToken()`, `setAccessToken()` 활용하여 Access Token 저장
   - `axiosRefreshToken()`을 이용해 Refresh Token으로 Access Token 자동 갱신

2. **Access Token 사용 방식 변경**
   - `axiosInstanceWithToken`의 `request interceptor`에서 토큰을 자동으로 삽입

3. **Refresh Token을 활용한 자동 로그인 유지**
   - `PrivateRoute.jsx`에서 페이지 진입 시 `axiosRefreshToken()` 호출
   - Access Token이 없거나 만료된 경우 Refresh Token을 이용해 자동 로그인 유지
   - Refresh Token도 쿠키를 통해 관리 (`withCredentials: true` 옵션 적용)

4. **로그아웃 처리 개선**
   - `axiosLogout()` 호출 시 서버에 로그아웃 요청 전송
   - `clearAll()`을 적용하여 메모리에서 Access Token 및 사용자 정보 삭제

5. **기존 localStorage 의존 코드 제거 및 최적화**
   - `getUserInfo()`, `ProfileContainer`, `ProfileEditPage` 등에서 localStorage 접근 코드 삭제
   - `setCurrentUser()`를 활용해 메모리에서 사용자 정보 관리

### 기대 효과
✅ **보안 강화:** Access Token은 메모리에서만 관리하고, Refresh Token은 쿠키를 통해 서버에서 관리
✅ **자동 로그인 유지:** Access Token이 만료되어도 Refresh Token을 활용해 로그인 유지 가능 
✅ **로딩 속도 개선:** 불필요한 localStorage 접근 제거로 성능 최적화
✅ **API 호출 일관성 유지:** 모든 요청에서 자동으로 Access Token이 포함됨