### PR TITLE
fix: Escape Liquid syntax in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,12 +260,14 @@ export default function PrivateRoute({ children, ...rest }) {
         userInfo ? (
           React.cloneElement(children, { ...props })
         ) : (
+          {% raw %}
           <Redirect
             to={{
               pathname: '/login',
               state: { from: props.location },
             }}
           />
+          {% endraw %}
         )
       }
     />


### PR DESCRIPTION
vercel error